### PR TITLE
Alyxx2214 backendAuth AuthLimit 1.0

### DIFF
--- a/Tests/Test_AuthLimit/Test_AuthLimit.py
+++ b/Tests/Test_AuthLimit/Test_AuthLimit.py
@@ -1,0 +1,26 @@
+import unittest
+#just to navigate back to test unit's directory
+import sys
+sys.path.append(sys.path[0]+"\\..\\..\\WorkingCode\\BackEnd\\PlayerSteamHandling")
+#debug path
+print(sys.path)
+import AuthLimit
+
+class TestSteamNameCheck(unittest.TestCase):
+	def testAuthLimit(self):
+		print("testing")
+		
+		c = AuthLimit.someTimer()
+		c.start()
+		c.inc()
+		c.inc()
+		c.inc()
+		c.getinc()
+		c.inc()
+		c.inc()
+		c.inc()
+		c.getinc()
+		
+# throw's a fit if you don't put this
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/Test_AuthLimit/Test_AuthLimit.py
+++ b/Tests/Test_AuthLimit/Test_AuthLimit.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 #just to navigate back to test unit's directory
 import sys
 sys.path.append(sys.path[0]+"\\..\\..\\WorkingCode\\BackEnd\\PlayerSteamHandling")
@@ -10,16 +11,17 @@ class TestSteamNameCheck(unittest.TestCase):
 	def testAuthLimit(self):
 		print("testing")
 		
-		c = AuthLimit.someTimer()
-		c.start()
-		c.inc()
-		c.inc()
-		c.inc()
-		c.getinc()
-		c.inc()
-		c.inc()
-		c.inc()
-		c.getinc()
+		c = AuthLimit.APILimiter()
+		c.incCt()
+		c.incCt()
+		c.incCt()
+		self.assertEqual(c.getinc(), 3)
+		c.incCt()
+		c.incCt()
+		c.incCt()
+		self.assertEqual(c.getinc(), 6)
+		#time.sleep(65)
+		self.assertEqual(c.getinc(), 0)
 		
 # throw's a fit if you don't put this
 if __name__ == '__main__':

--- a/Tests/Test_AuthLimit/Test_AuthLimit.py
+++ b/Tests/Test_AuthLimit/Test_AuthLimit.py
@@ -9,19 +9,41 @@ import AuthLimit
 
 class TestSteamNameCheck(unittest.TestCase):
 	def testAuthLimit(self):
-		print("testing")
 		
-		c = AuthLimit.APILimiter()
-		c.incCt()
-		c.incCt()
-		c.incCt()
-		self.assertEqual(c.getinc(), 3)
-		c.incCt()
-		c.incCt()
-		c.incCt()
-		self.assertEqual(c.getinc(), 6)
+		### This next part
+		### Is testing creating
+		### and incrementing
+
+		print("b4 setting scheduler")
+		t_var = AuthLimit.AuthTimer()
+
+		print("something's happening")
+		t_var.inc()
+		t_var.inc()
+		t_var.inc()
+		
+		self.assertEqual(t_var.getinc(), 3)
+
+		print("sleep for 10s")
+
+		time.sleep(10)
+
+		t_var.inc()
+		t_var.inc()
+		t_var.inc()
+		
+		
+		self.assertEqual(t_var.getinc(), 6)
+
+		print("Sleep for 60s")
+		time.sleep(60)
+		
+		self.assertEqual(t_var.getinc(), 0)
+		
+		print(t_var.getinc())
+
+		print("Can end :thumbs_up:")
 		#time.sleep(65)
-		self.assertEqual(c.getinc(), 0)
 		
 # throw's a fit if you don't put this
 if __name__ == '__main__':

--- a/Tests/Test_AuthLimit/Test_AuthLimit.py
+++ b/Tests/Test_AuthLimit/Test_AuthLimit.py
@@ -1,8 +1,5 @@
 import unittest
-<<<<<<< HEAD
 import time
-=======
->>>>>>> fa9bebe213e8349a7337ac6a4c4dd263b62b5854
 #just to navigate back to test unit's directory
 import sys
 sys.path.append(sys.path[0]+"\\..\\..\\WorkingCode\\BackEnd\\PlayerSteamHandling")
@@ -14,7 +11,6 @@ class TestSteamNameCheck(unittest.TestCase):
 	def testAuthLimit(self):
 		print("testing")
 		
-<<<<<<< HEAD
 		c = AuthLimit.APILimiter()
 		c.incCt()
 		c.incCt()
@@ -26,18 +22,6 @@ class TestSteamNameCheck(unittest.TestCase):
 		self.assertEqual(c.getinc(), 6)
 		#time.sleep(65)
 		self.assertEqual(c.getinc(), 0)
-=======
-		c = AuthLimit.someTimer()
-		c.start()
-		c.inc()
-		c.inc()
-		c.inc()
-		c.getinc()
-		c.inc()
-		c.inc()
-		c.inc()
-		c.getinc()
->>>>>>> fa9bebe213e8349a7337ac6a4c4dd263b62b5854
 		
 # throw's a fit if you don't put this
 if __name__ == '__main__':

--- a/Tests/Test_SteamName/Test_SteamNameCheck.py
+++ b/Tests/Test_SteamName/Test_SteamNameCheck.py
@@ -1,7 +1,6 @@
 #just to navigate back to test unit's directory
 import sys
-sys.path.append(sys.path[0]+"\\..\\..")
-
+sys.path.append(sys.path[0]+"\\..\\..\\WorkingCode\\BackEnd\\PlayerSteamHandling")
 #debug path
 #print(sys.path)
 

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,0 +1,28 @@
+import threading    
+
+class AuthLimiter:
+    num = 0
+    timer = 0
+    
+    def __init__(self):
+        self.StartTimer()
+
+    def inc(self):
+        self.num += 1
+        
+    def StartTimer(self):
+        self.timer = threading.Timer(60, self.ClearNum())
+        self.timer.start()
+        #do stuff
+
+    def ClearNum(self):
+        self.num = 0
+        print("Resetting the counter")
+        
+    def CanCall(self):
+        if (self.num < 60):  return True
+        else: return False
+        
+c = AuthLimiter()
+c.inc()
+c.inc()

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,39 +1,24 @@
-import threading
-import time
-
-
-class Timer(threading.Thread):
+import sched, time
+class APILimiter:
+    incCt = 0
 
     def __init__(self):
-        self._timer_runs = threading.Event()
-        self._timer_runs.set()
-        super().__init__()
+        interval = 60
+        self.my_scheduler = sched.scheduler(time.time, time.sleep)
+        self.my_scheduler.enter(interval, 1, self.reset, (self.my_scheduler,))
+        self.my_scheduler.run()
 
-    def run(self):
-        while self._timer_runs.is_set():
-            self.timer()
-            time.sleep(self.__class__.interval)
+    def reset(self, scheduler): 
+        # schedule the next call first
+        scheduler.enter(60, 1, self.reset, (scheduler,))
+        print("Doing stuff...")
+        self.incCt = 0
+        # then do your stuff
 
-    def stop(self):
-        self._timer_runs.clear()
-
-class someTimer(Timer):
-    interval = 60
-    inc = 0    
-    def __init__(self):
-        self.inc = 0
-        self.interval = 60
-
-    #func to ex
-    def timer(self):
-        print("Clear inc:" + self.inc)
-        self.inc = 0
+    def incCt(self):
+        self.incCt = self.incCt + 1
         
-    def inc(self):
-        self.inc = self.inc + 1
-        
-    def caninc(self) -> bool:
-        return True  if self.inc<60 else False
-
     def getinc(self):
-        return self.inc
+        return self.incCt
+        
+    

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,29 +1,3 @@
-<<<<<<< HEAD
-import sched, time
-class APILimiter:
-    incCt = 0
-
-    def __init__(self):
-        interval = 60
-        self.my_scheduler = sched.scheduler(time.time, time.sleep)
-        self.my_scheduler.enter(interval, 1, self.reset, (self.my_scheduler,))
-        self.my_scheduler.run()
-
-    def reset(self, scheduler): 
-        # schedule the next call first
-        scheduler.enter(60, 1, self.reset, (scheduler,))
-        print("Doing stuff...")
-        self.incCt = 0
-        # then do your stuff
-
-    def incCt(self):
-        self.incCt = self.incCt + 1
-        
-    def getinc(self):
-        return self.incCt
-        
-    
-=======
 import threading
 import time
 
@@ -63,4 +37,3 @@ class someTimer(Timer):
 
     def getinc(self):
         return self.inc
->>>>>>> fa9bebe213e8349a7337ac6a4c4dd263b62b5854

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,39 +1,44 @@
-import threading
-import time
+import threading, time
 
+class AuthTimer:
+    
+    #Literally will never run. This avoids the "t doesn't exist" bs
+    def nothin(self):
+        print("literally nothing")
 
-class Timer(threading.Thread):
-
-    def __init__(self):
-        self._timer_runs = threading.Event()
-        self._timer_runs.set()
-        super().__init__()
-
-    def run(self):
-        while self._timer_runs.is_set():
-            self.timer()
-            time.sleep(self.__class__.interval)
-
-    def stop(self):
-        self._timer_runs.clear()
-
-class someTimer(Timer):
+    #IncrVal goes up with every API Call
+    incrVal = 0
+    #Interval is how many seconds before clearing incrVal
     interval = 60
-    inc = 0    
+
+    #t is the threading timer
+    t = threading.Timer(interval, nothin)
+
+    #Resets the incrVal
+    def do_something(self): 
+        # Do your stuff
+        print("Resetting inc...")
+        self.incrVal = 0
+        
+        #then reschedule (and re-start) your timer
+        self.t = threading.Timer(self.interval, self.do_something)
+        self.t.start()
+
+    #Initialize our timer
     def __init__(self):
-        self.inc = 0
+        self.incrVal = 0
         self.interval = 60
-
-    #func to ex
-    def timer(self):
-        print("Clear inc:" + self.inc)
-        self.inc = 0
+        self.do_something()
         
-    def inc(self):
-        self.inc = self.inc + 1
-        
-    def caninc(self) -> bool:
-        return True  if self.inc<60 else False
-
+    #Getter for incrVal
     def getinc(self):
-        return self.inc
+        return self.incrVal
+    
+    #If incrval < 60 every min, then True; if no more API allowed in the minute, return False
+    def canInc(self):
+        return True if self.incrVal < 60 else False
+    
+    # increments incrVal
+    def inc(self):
+        self.incrVal += 1
+    

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,28 +1,39 @@
-import threading    
+import threading
+import time
 
-class AuthLimiter:
-    num = 0
-    timer = 0
-    
+
+class Timer(threading.Thread):
+
     def __init__(self):
-        self.StartTimer()
+        self._timer_runs = threading.Event()
+        self._timer_runs.set()
+        super().__init__()
 
+    def run(self):
+        while self._timer_runs.is_set():
+            self.timer()
+            time.sleep(self.__class__.interval)
+
+    def stop(self):
+        self._timer_runs.clear()
+
+class someTimer(Timer):
+    interval = 60
+    inc = 0    
+    def __init__(self):
+        self.inc = 0
+        self.interval = 60
+
+    #func to ex
+    def timer(self):
+        print("Clear inc:" + self.inc)
+        self.inc = 0
+        
     def inc(self):
-        self.num += 1
+        self.inc = self.inc + 1
         
-    def StartTimer(self):
-        self.timer = threading.Timer(60, self.ClearNum())
-        self.timer.start()
-        #do stuff
+    def caninc(self) -> bool:
+        return True  if self.inc<60 else False
 
-    def ClearNum(self):
-        self.num = 0
-        print("Resetting the counter")
-        
-    def CanCall(self):
-        if (self.num < 60):  return True
-        else: return False
-        
-c = AuthLimiter()
-c.inc()
-c.inc()
+    def getinc(self):
+        return self.inc


### PR DESCRIPTION
added a class that can be incremented up to 60 times a minute. This class will be used to "prevent" our API from making too many calls in a minute (In an attempt to keep our key from getting banned)

need to make timerVar = AuthTimer(); timerVar.canInc() will return True if we can call again, or False if we've already made our 60 calls. timerVar.inc() will increment the number of times we call the API. Every 60 seconds, that incrementor is reset back to 0.

Will add a ticket for the API team to implement this class into their calls