### PR TITLE
reworked timer class, improved testing

### DIFF
--- a/Tests/Test_AuthLimit/Test_AuthLimit.py
+++ b/Tests/Test_AuthLimit/Test_AuthLimit.py
@@ -7,44 +7,46 @@ sys.path.append(sys.path[0]+"\\..\\..\\WorkingCode\\BackEnd\\PlayerSteamHandling
 print(sys.path)
 import AuthLimit
 
-class TestSteamNameCheck(unittest.TestCase):
+class TestAuthLimit(unittest.TestCase):
 	def testAuthLimit(self):
 		
 		### This next part
 		### Is testing creating
 		### and incrementing
 
-		print("b4 setting scheduler")
-		t_var = AuthLimit.AuthTimer()
-
-		print("something's happening")
-		t_var.inc()
-		t_var.inc()
-		t_var.inc()
+		#print("b4 setting scheduler") # debug
+		self.t_var = AuthLimit.AuthTimer()
 		
-		self.assertEqual(t_var.getinc(), 3)
+		for num in range(1,self.t_var.maxIncrVal+1):
+			self.assertTrue(self.t_var.canInc())
+			self.assertEqual(self.t_var.getInc(),num)
+		#incr should equal its max val
+		self.assertEqual(self.t_var.getInc(), self.t_var.maxIncrVal)
+		self.assertFalse(self.t_var.canInc())
 
-		print("sleep for 10s")
+		print(f"incr to max: {self.t_var.getInc()}")
+		print(f"sleep for {self.t_var.interval/6}s (some time b4 reset)") #terminal clarification
 
-		time.sleep(10)
-
-		t_var.inc()
-		t_var.inc()
-		t_var.inc()
+		time.sleep(self.t_var.interval/6)
 		
+		#still full
+		self.assertEqual(self.t_var.getInc(), self.t_var.maxIncrVal)
+		self.assertFalse(self.t_var.canInc())
 		
-		self.assertEqual(t_var.getinc(), 6)
+		print(f"Still max: {self.t_var.getInc()}")
 
-		print("Sleep for 60s")
-		time.sleep(60)
+		print(f"Sleep for {self.t_var.interval}s (till reset)") #wait for the timer to reset (60s)
 		
-		self.assertEqual(t_var.getinc(), 0)
+		time.sleep(self.t_var.interval)
 		
-		print(t_var.getinc())
-
+		self.assertEqual(self.t_var.getInc(),0)
+		
+		print(f"Now 0: {self.t_var.getInc()}", )
 		print("Can end :thumbs_up:")
 		#time.sleep(65)
+
 		
+
 # throw's a fit if you don't put this
 if __name__ == '__main__':
     unittest.main()

--- a/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
+++ b/WorkingCode/BackEnd/PlayerSteamHandling/AuthLimit.py
@@ -1,4 +1,4 @@
-import threading, time
+import threading
 
 class AuthTimer:
     
@@ -8,6 +8,8 @@ class AuthTimer:
 
     #IncrVal goes up with every API Call
     incrVal = 0
+    #max IncrVal
+    maxIncrVal = 60
     #Interval is how many seconds before clearing incrVal
     interval = 60
 
@@ -15,30 +17,39 @@ class AuthTimer:
     t = threading.Timer(interval, nothin)
 
     #Resets the incrVal
-    def do_something(self): 
-        # Do your stuff
-        print("Resetting inc...")
+    def reset(self): 
+        # Do the stuff
+        #print("Resetting inc...") #debugging
         self.incrVal = 0
         
-        #then reschedule (and re-start) your timer
-        self.t = threading.Timer(self.interval, self.do_something)
+        #then reschedule (and re-start) the timer
+        self.t = threading.Timer(self.interval, self.reset)
         self.t.start()
 
     #Initialize our timer
     def __init__(self):
         self.incrVal = 0
+        self.maxIncrVal = 60
         self.interval = 60
-        self.do_something()
+        self.reset()
         
     #Getter for incrVal
-    def getinc(self):
+    '''Returns the # of api calls made in the last minute
+        Returns:
+            incrementValue (int): Int value of # of calls made in the minute
+    '''
+    def getInc(self) -> int:
         return self.incrVal
     
     #If incrval < 60 every min, then True; if no more API allowed in the minute, return False
-    def canInc(self):
-        return True if self.incrVal < 60 else False
-    
-    # increments incrVal
-    def inc(self):
-        self.incrVal += 1
+    '''Returns True or false wether another API call can be made
+        Returns:
+            #incrementValue < 60 ? Y: True ; N: False
+    '''
+    def canInc(self) -> bool:
+        if self.incrVal < self.maxIncrVal: 
+            self.incrVal = self.incrVal+1
+            return True
+        else:
+            return False
     


### PR DESCRIPTION
ClassObject = AuthLimit.AuthTimer()
ClassObject.canInc() -> If apiCallsInMinute<60: true ; else: false
ClassObject.getInc() -> # of times canInc has been called before last reset

AuthTimer has a value incrVal. This gets incremented every time canInc() is called (until it reaches 60). After 60 seconds, that value gets reset to 0. Calling getInc() will give this value.